### PR TITLE
Add file forwarding script

### DIFF
--- a/forward_args
+++ b/forward_args
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# run Armagetron Advanced with the given parmeters in flatpak
+# applies appropriate forwarding and permission granting
+
+FLATPAK_ID=${FLATPAK_ID:-org.armagetronad.ArmagetronAdvanced}
+FLATPAK_BRANCH=${FLATPAK_BRANCH:-alpha}
+
+vardir=false
+if echo "$@" | grep -q -- --vardir; then
+    vardir=true
+fi
+
+filesystems=()
+params=()
+while ! test -z "$1"; do
+    case "$1" in
+        --record)
+            # next argument needs to exist for forwarding to work
+            touch "$2"
+            ;;
+        --autoresourcedir)
+            # resource cache: needs to exist, mount writable
+            abs=`readlink -f "$2"`
+            filesystems+=(--filesystem="${abs}:create")
+            ;;
+        --vardir)
+            # settings: needs to exist, mount writable
+            abs=`readlink -f "$2"`
+            filesystems+=(--filesystem="${abs}:create")
+            ;;
+        --userdatadir)
+            # user data: if not explicitly given elsewhere, var subdirectory needs to exist and be writable
+            abs=`readlink -f "$2"`
+            filesystems+=(--filesystem="${abs}:ro")
+            if test ${vardir} = false; then
+                filesystems+=(--filesystem="${abs}/var:create")
+            fi
+            ;;
+        --*dir)
+            # other directories just need to be readable
+            abs=`readlink -f "$2"`
+            filesystems+=(--filesystem="${abs}:ro")
+            ;;
+
+    esac
+
+    if test "$1" == --record; then
+        # next argument needs to exist for forwarding to work
+        touch "$2"
+    fi
+
+    if echo "$1" | grep -q '^-' || ! test -r "$1"; then
+        params+=("$1")
+    else
+        params+=("@@")
+        params+=("$1")
+        params+=("@@")
+    fi
+    
+    shift
+done
+
+if flatpak-spawn -h > /dev/null 2>&1; then
+    set -x
+    flatpak-spawn --watch-bus --host flatpak run --file-forwarding --branch=${FLATPAK_BRANCH} "${filesystems[@]}" ${FLATPAK_ID} "${params[@]}"
+else
+    set -x
+    flatpak run --file-forwarding --branch=${FLATPAK_BRANCH} "${filesystems[@]}" ${FLATPAK_ID} "${params[@]}"
+fi

--- a/forward_args
+++ b/forward_args
@@ -4,7 +4,7 @@
 # applies appropriate forwarding and permission granting
 
 FLATPAK_ID=${FLATPAK_ID:-org.armagetronad.ArmagetronAdvanced}
-FLATPAK_BRANCH=${FLATPAK_BRANCH:-alpha}
+FLATPAK_BRANCH=${FLATPAK_BRANCH:-stable}
 
 vardir=false
 if echo "$@" | grep -q -- --vardir; then

--- a/org.armagetronad.ArmagetronAdvanced.json
+++ b/org.armagetronad.ArmagetronAdvanced.json
@@ -48,6 +48,10 @@
                     "path": "armagetronad-appdata.patch"
                 },
                 {
+                    "type": "file",
+                    "path": "forward_args"
+                },
+                {
                     "type": "script",
                     "dest-filename": "autogen.sh",
                     "commands": [
@@ -57,6 +61,7 @@
                 }
             ],
             "post-install": [
+                "install -Dm755 forward_args ${FLATPAK_DEST}/bin/forward_args",
                 "sed -i /app/share/metainfo/*.appdata.xml -e 's,.desktop</id>,</id>,' -e 's,<!-- <launchable,<launchable,' -e 's,</launchable> -->,</launchable>,'",
                 "install -Dm644 /app/share/metainfo/*.appdata.xml /app/share/appdata/org.armagetronad.ArmagetronAdvanced.appdata.xml",
                 "desktop-file-edit --set-key=Icon --set-value=org.armagetronad.ArmagetronAdvanced /app/share/ArmagetronAdvanced/desktop/*.desktop",


### PR DESCRIPTION
The problem: On the command line, we accept a couple of file related arguments. The most important one would be playback of recordings; these are files where we simply record all the inputs to the game (keyboard, time passed, network input...). Originally intended just as a debugging aid, it turned out to also be useful for recording tournament games. Anyway, since we went for the strictest sensible file system sandboxing, if you do it now the naive way:

    flatpak run org.armagetronad.ArmagetronAdvanced <recording file>

it doesn't work because we likely don't have access to that file. The .desktop file installed by flatpak does the right thing already for this particular case and would call

    flatpak run --file-forwarding org.armagetronad.ArmagetronBeta @@ <recording file> @@

But there are more cases. Of course, we also need to be able to create recordings; file forwarding only works for files that already exist, so one needs to first create a dummy file:

    touch <recording file>; flatpak run --file-forwarding org.armagetronad.ArmagetronBeta --record @@ <recording file> @@

And, much less used, we also support passing in alternative directories for the user configuration, data and cache directories; we need to add appropriate --filesystem permissions for read and possibly write access and create the directories if they don't exist yet. This gets too much work and stuff to remember to do by hand.

So, I wanted to float this idea up and get some feedback:
This PR adds a script, forward_args, that takes regular command line arguments and transforms them into a call with all the appropriate filesystem permissions and with necessary file stubs and directories created.

Now, putting that script into THIS flatpak isn't super ideal:
 - It violates the guideline that functionality should not be added to the flatpak itself, though I'd argue that this is a case where the functionality added is flatpak specific.
 - It is a bit awkward to call. You either have to locate it on the host filesystem in a hopefully invariant place (possible right now, but a Flatpak implementation detail) OR call it inside the sandbox, giving it full permissions to escape the sandbox again and call the actual game.

Most people won't need this script. An alternative would be to just put it into a separate Flatpak on our own repository. It can get the appropriate permissions and would therefore be easier to call for those who do need it.

Thoughts welcome. Heh. I think I have already talked myself out of it :) I'll try the separate Flatpak approach, too.